### PR TITLE
Fixed syntax in  README.md   

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ interface DemoModule {
   @Provides fun demoClass(
     somethingElse: SomethingElse
   ): Demo {
-    return Demo(somethingElse
+    return Demo(somethingElse)
   }
   
   @Provides fun somethingElse(): SomethingElse {


### PR DESCRIPTION
Fixed Kotlin syntax in  README.md   